### PR TITLE
Add Amazon affiliate links to books we've read

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,15 @@ layout: default
   <h2>Books we&rsquo;ve read</h2>
 
   <ul>
-    <li><a href="http://computationbook.com/">Understanding Computation</a></li>
-    <li><a href="http://www.ccs.neu.edu/home/matthias/BTLS/">The Little Schemer</a></li>
+    <li><a href="http://computationbook.com/">Understanding Computation</a> (<a href="http://www.amazon.co.uk/gp/product/1449329276/ref=as_li_tl?ie=UTF8&camp=1634&creative=19450&creativeASIN=1449329276&linkCode=as2&tag=computationclub-21&linkId=Y33MSPW2C4U3YVP5">buy on Amazon</a>)</li>
+    <li><a href="http://www.ccs.neu.edu/home/matthias/BTLS/">The Little Schemer</a> (<a href="http://www.amazon.co.uk/gp/product/0262560992/ref=as_li_tl?ie=UTF8&camp=1634&creative=19450&creativeASIN=0262560992&linkCode=as2&tag=computationclub-21&linkId=7LA3DI5O7QPJD2UM">buy on Amazon</a>)</li>
   </ul>
+
+  <p>If you buy these books using the Amazon links, London Computation
+  Club gets a little kickback via the Amazon affiliate programme. We
+  use that kickback to buy copies of the books for our library, to
+  assist members or potential members who otherwise wouldn't be able
+  to afford the book.<p>
 </section>
 
 <section>


### PR DESCRIPTION
Addresses issue #6.

I've added these links to the books we've read. They were generated using the
Amazon affiliate tools. We can probably auto-generate them and add them
automatically if we move the book lists into `_data/`, but we can do
that at a later stage.

For the record, the affiliate account is administered by me, Chris Lowis, but
I commit to using any revenues to purchase books to donate to the London
Computation Club for the use of any members.
