### PR TITLE
Draw 1 cell per pixel, then scale canvas up

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,15 +37,13 @@
 
       (function () {
         var ruleNumberId = 'rule-number',
-            canvasId = 'cellular-automaton',
-            cellSize = 2;
+            canvasId = 'cellular-automaton';
 
         document.addEventListener('DOMContentLoaded', function () {
           var ruleNumber = document.getElementById(ruleNumberId);
 
           var cellGrid = new CellGrid({
-            canvas: document.getElementById(canvasId),
-            cellSize: cellSize
+            canvas: document.getElementById(canvasId)
           });
 
           var cellularAutomaton = new CellularAutomaton({

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
   </head>
 
   <body>
-    <canvas id="cellular-automaton" width="800" height="50"></canvas>
+    <canvas id="cellular-automaton" width="400" height="25"></canvas>
 
     <h1><a href="{{ site.url }}/">London Computation Club</a></h1>
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -65,3 +65,7 @@ input[type=number] {
 .bordered {
   border: 1px solid #ddd;
 }
+
+#cellular-automaton {
+  width: 100%;
+}

--- a/js/cell-grid.js
+++ b/js/cell-grid.js
@@ -2,40 +2,37 @@
   'use strict';
 
   var CellGrid = (function () {
-    var scrollContext = function (context, columns, rows, cellSize) {
-      var width = columns * cellSize, height = rows * cellSize;
-
-      var imageData = context.getImageData(0, cellSize, width, height - cellSize);
+    var scrollContext = function (context, width, height) {
+      var imageData = context.getImageData(0, 1, width, height - 1);
       context.putImageData(imageData, 0, 0);
-      context.clearRect(0, height - cellSize, width, cellSize);
+      context.clearRect(0, height - 1, width, 1);
     };
 
     var nextRow = function () {
       if (this.row < this.rows - 1) {
         ++this.row;
       } else {
-        scrollContext(this.context, this.columns, this.rows, this.cellSize);
+        scrollContext(this.context, this.columns, this.rows);
       }
     };
 
-    var drawCell = function (context, column, row, size) {
-      context.fillRect(column * size, row * size, size, size);
+    var drawCell = function (context, column, row) {
+      context.fillRect(column, row, 1, 1);
     };
 
     var constructor = function (options) {
       this.canvas = options.canvas;
-      this.cellSize = options.cellSize;
 
       this.row = 0;
       this.context = this.canvas.getContext('2d');
-      this.columns = Math.floor(this.canvas.width / this.cellSize);
-      this.rows = Math.floor(this.canvas.height / this.cellSize);
+      this.columns = this.canvas.width;
+      this.rows = this.canvas.height;
     };
 
     constructor.prototype.draw = function (cellularAutomaton) {
       for (var column = 0; column < this.columns; ++column) {
         if (cellularAutomaton.getCell(column)) {
-          drawCell(this.context, column, this.row, this.cellSize);
+          drawCell(this.context, column, this.row);
         }
       }
 


### PR DESCRIPTION
In principle this is a much more sensible way of doing things, since it eliminates the arithmetic around `cellSize` and probably makes the scrolling less CPU-intensive (#10) because we’re not copying as much image data. This technique might also make it easier to customise the page for mobile devices (#29).

In practice it’s **not ready** because scaling the `<canvas>` with CSS makes it blurry — browsers use [bilinear interpolation](http://en.wikipedia.org/wiki/Bilinear_filtering) or similar to resample scaled images, rather than causing pixelation with [nearest-neighbour](http://en.wikipedia.org/wiki/Nearest-neighbor_interpolation), but we _want_ pixelation in this case. I’ve tried various fixes (e.g. CSS 3’s [`image-rendering` property](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering)) but none of them seem to work, at least in Chrome.

Can anyone make this work?
