### PR TITLE
Encourage members to vote and propose chapters

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,14 @@ layout: default
     <li>(none)</li>
   {% endif %}
   </ul>
+
+  <p>
+  Everyone is welcome to get involved and help decide which chapter to read
+  next. You can cast your votes in our
+  <a href="http://computationclub-slack.herokuapp.com/">Slack channel</a>
+  or
+  <a href="https://github.com/computationclub/computationclub.github.io/wiki/Call-For-Proposals">put a proposal forward</a>.
+  </p>
 </section>
 
 <section id="members">


### PR DESCRIPTION
Once upon a time, there was a Computation Club meeting.
In this meeting, our esteemed members partook in the
reading and discussion of the chapter on "Sorting" from
the New Turing Omnibus.

Said members didn't enjoy this chapter as much as others
and decided that this may have been due to the process
that lead to its election as the next chapter to be read.

And so, a short retrospective was held at the conclusion
of this meeting and the decision was made to amend the
current process for electing chapters to be read by the
club.

In response to this, an RFC page was imagined that
invited members to influence others' votes through the
use of persuasive techniques often observed in
the polical arenas of the elite.

That RFC page was realised and this commit stands as
memorial of that.