### PR TITLE
Add the next meeting to the calendar

### DIFF
--- a/_data/meetings.yml
+++ b/_data/meetings.yml
@@ -1,3 +1,8 @@
+- date: 2016-01-19
+  title: Chapter 16, Genetic Algorithms
+  url: http://lanyrd.com/2016/london-computation-club-genetic-algorithms/
+  book: The New Turing Omnibus
+
 - date: 2015-12-01
   title: Chapter 9, Mathematical Research
   url: http://lanyrd.com/2015/london-computation-club-mandelbrot/


### PR DESCRIPTION
Depends on the Lanyrd slug being set to `london-computation-club-genetic-algorithms`

I don't have rights to do this as far as I can tell.