### PR TITLE
Simplify set up instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ http://london.computation.club/
 
 * [Ruby](https://www.ruby-lang.org/en/);
 * [Bundler](http://bundler.io/);
-* [Foreman](http://ddollar.github.io/foreman/) (optional).
 
 ## Installation
 
@@ -15,7 +14,5 @@ http://london.computation.club/
 $ git clone https://github.com/computationclub/computationclub.github.io.git
 $ cd computationclub.github.io
 $ bundle install
-$ foreman start
-// or
 $ jekyll serve --watch
 ```


### PR DESCRIPTION
By removing the suggestion of starting it with foreman because we don't need two options and foreman is not installed as part of the bundled gems