### PR TITLE
Add issue template for meetings

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,52 @@
+### As soon as you're assigned
+
+- [ ] Assign yourself this issue! (If you're not a member of [London Computation Club](https://github.com/computationclub) on GitHub, ask someone on Slack to add you.)
+- [ ] Make sure you have access to the [Buffer](http://buffer.com) account for the club - this is how you'll tweet. (Ask on #general in Slack and someone will DM you the credentials.)
+- [ ] Make sure you can commit to the Computation Club website repository
+
+### The day after you're assigned
+
+- [ ] Remove the previous meeting’s chapter from Slack (if scanned; you may need a Slack admin user to do this)
+- [ ] Encourage a write up of the previous meeting in Slack
+- [ ] Add a link to the previous meeting’s write up to the: 
+  * [ ] [wiki homepage](https://github.com/computationclub/computationclub.github.io/wiki/Home/_edit)
+  * [ ] [wiki sidebar](https://github.com/computationclub/computationclub.github.io/wiki/_Sidebar/_edit)
+  * [ ] [meetings.yml file](https://github.com/computationclub/computationclub.github.io/edit/master/_data/meetings.yml)
+- [ ] Announce the write-up!
+  * [ ] Slack
+  * [ ] The mailing list
+  * [ ] Twitter
+
+### Same day / A few days later (but not too long!)
+
+- [ ] Double check that someone (Leo or Dan) at Geckoboard is able to host on the planned date; if not:
+  * [ ] Make a Doodle poll with potential dates
+  * [ ] Announce the poll on Slack
+  * [ ] Announce the poll on the mailing list
+  * [ ] Announce the poll on Twitter
+  * [ ] Pick a date
+- [ ] Identify the next chapter(s) to read for the next meeting (or any reading material for a non-book meeting)
+- [ ] Create an online event using an appropriate service that allows us to measure attendance.  We prefer to add it to [Attending.io](https://attending.io) as Lanyrd is too unreliable. Add information about how to access the venue (e.g. entering through HelloFresh).
+- [ ] Announce the meeting!
+  * [ ] Slack
+  * [ ] The [mailing list](https://groups.google.com/forum/#!forum/london-computation-club)
+  * [ ] Twitter
+- [ ] Add the next meeting to the Computation Club website by [editing the meetings.yml file](https://github.com/computationclub/computationclub.github.io/edit/master/_data/meetings.yml). Make sure your YAML is well-formatted - don't leave any colons in titles, for example!
+- [ ] Try to get a copy of the chapter scanned and put it on Slack as a single .pdf file ([Office Lens](https://itunes.apple.com/gb/app/office-lens/id975925059?mt=8) app might be useful to "scan" chapters with your phone)
+
+### A day or two before the meeting
+
+- [ ] Remind people about the next meeting
+  * [ ] Slack
+  * [ ] The [mailing list](https://groups.google.com/forum/#!forum/london-computation-club)
+  * [ ] Twitter
+- [ ] [Update the meeting checklist template](https://github.com/computationclub/computationclub.github.io/wiki/Checklist-Template%3A-Book-Meeting/_edit) based on your experiences using it. Maybe we've missed something, or the timings need to be improved?
+- [ ] Copy [the source of meeting checklist template](https://github.com/computationclub/computationclub.github.io/wiki/Checklist-Template%3A-Book-Meeting/_edit) to a new issue, called "Organise next meeting".
+
+### At the meeting
+
+- [ ] Pick an organizer for the next meeting
+
+### Finally
+
+- [ ] Mark this issue as done! Excellently executed!


### PR DESCRIPTION
Based on the book meeting template from the wiki (https://github.com/computationclub/computationclub.github.io/wiki/Checklist-Template%3A-Book-Meeting), create a GitHub issue template that will be used when creating new issues.

The downside is that this means _all_ new issues will use this template so anyone wanting to report an issue with the site would also have this content preloaded into their issue.