### PR TITLE
Add hour to meeting

### DIFF
--- a/_includes/meeting.html
+++ b/_includes/meeting.html
@@ -1,4 +1,4 @@
-{% assign meeting_date = meeting.date | date: "%A %-dth %B %Y" | replace: "1th", "1st" | replace: "2th", "2nd" | replace: "3th", "3rd" | replace: "11st", "11th" | replace: "12nd", "12th" | replace: "13rd", "13th" %}
+{% assign meeting_date = meeting.date | date: "6:30 PM-8:30 PM %A %-dth %B %Y" | replace: "1th", "1st" | replace: "2th", "2nd" | replace: "3th", "3rd" | replace: "11st", "11th" | replace: "12nd", "12th" | replace: "13rd", "13th" %}
 <li>
   {% if meeting.url != null %}
     {% if meeting.title != null %}


### PR DESCRIPTION
The hour is missing when you look at the index page, yet it's always going to be 18:30 PM according to this: https://github.com/computationclub/computationclub.github.io/blob/master/meetings.ics#L29

I've taken the liberty to add it, in case there are other people like me who don't know when it takes places and have to click around to find out.