### PR TITLE
Change embedded map to mention geckoboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ layout: default
 </section>
 
 <section id="future-meetings" class="box">
-  <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2482.528139098825!2d-0.0849826845266849!3d51.52187231746636!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761cae237d267f%3A0x4b8c1604d05dc1cb!2s60+Worship+St%2C+Hackney%2C+London+EC2A!5e0!3m2!1sen!2suk!4v1478805378907" width="400" height="350" frameborder="0" style="border:0" allowfullscreen></iframe>
+  <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2482.52832001599!2d-0.0849826826017174!3d51.52186899872733!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761cba93723535%3A0x6f6049fe92df0d80!2sGeckoboard!5e0!3m2!1sen!2suk!4v1515596795731" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
   <h2>Future meetings</h2>
 
   <ul>


### PR DESCRIPTION
It's the same address, but this version of the embedded map should make it clearer we're meeting in Geckoboard's offices, not just 60 Worship St.