### PR TITLE
Remove Joel from the list of volunteers for the code of conduct

### DIFF
--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -34,7 +34,6 @@ layout: default
 <h3>Volunteer team</h3>
 
 <ul>
-  <li>Joel Chippindale (<a href="https://twitter.com/joelchippindale">@joelchippindale</a>, <a href="ma&#105;lto&#58;j&#37;&#54;Fel&#37;&#52;0mocos&#111;&#46;c&#111;&#46;u%&#54;&#66;">&#106;o&#101;l&#64;m&#111;cos&#111;&#46;c&#111;&#46;u&#107;</a>)</li>
   <li>Paul Mucur (<a href="https://twitter.com/mudge">@mudge</a>, <a href="mailt&#111;&#58;mu%64&#103;e%&#52;0%&#54;Dudge%2En%61me">mud&#103;e&#64;mu&#100;ge&#46;&#110;&#97;m&#101;</a>)</li>
 </ul>
 


### PR DESCRIPTION
Because he only attends on an infrequent basis these days meaning that he is much less familiar to members and so less likely to be trusted should someone wish to contact a volunteer with concerns about an incident.